### PR TITLE
Corrected specifiers in Blog

### DIFF
--- a/src/main/java/com/api/mocktailstore/entities/Blog.java
+++ b/src/main/java/com/api/mocktailstore/entities/Blog.java
@@ -6,6 +6,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 
 import org.hibernate.annotations.GenericGenerator;
 
@@ -18,8 +19,10 @@ public class Blog implements Serializable {
 	@GenericGenerator(name = "native", strategy = "native")
 	private long blogId;
 	private String title;
+
+	@Lob
 	private String content;
-	private String visibile;
+	private boolean visibile;
 	private String author;
 
 	public Blog() {
@@ -58,11 +61,11 @@ public class Blog implements Serializable {
 		this.content = content;
 	}
 
-	public String getVisibile() {
+	public boolean getVisibile() {
 		return visibile;
 	}
 
-	public void setVisibile(String visibile) {
+	public void setVisibile(boolean visibile) {
 		this.visibile = visibile;
 	}
 


### PR DESCRIPTION
Corrected content specifier in Blog, so now datatype of content will be Long text, datatype of visible will be bit.

Please review and merge.